### PR TITLE
Alteração do caminho para buscar o arquivo de configurações

### DIFF
--- a/backend/ResponseManager/ProductManager/Util/FileUtil.cs
+++ b/backend/ResponseManager/ProductManager/Util/FileUtil.cs
@@ -10,7 +10,7 @@ namespace ProductManager.Util {
     public static class FileUtil {
 
         public static string getContentFile() {
-            return File.ReadAllText("d:\\DZHosts\\LocalUser\\wilkoliveira\\www.wilkoliveira.somee.com\\config.ini");
+            return File.ReadAllText(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments) + "\\config_CSVPath.ini");
         }
 
         public static void appendToCSVFile(Response response, string pathCSVFile) {


### PR DESCRIPTION
O arquivo config_CSVPath deverá existir na pasta documentos do computador. Este arquivo deve conter o caminho do arquivo CSV de onde ficarão as informações.